### PR TITLE
Rewrite to use io.Reader and io.Writer

### DIFF
--- a/xml/client.go
+++ b/xml/client.go
@@ -4,23 +4,24 @@
 
 package xml
 
-import (
-	"io"
-	"io/ioutil"
-)
+import "io"
 
 // EncodeClientRequest encodes parameters for a XML-RPC client request.
 func EncodeClientRequest(method string, args interface{}) ([]byte, error) {
-	xml, err := rpcRequest2XML(method, args)
-	return []byte(xml), err
+	buf := bufPool.Get()
+	defer bufPool.Put(buf)
+	err := EncodeClientRequestW(buf, method, args)
+	return buf.Bytes(), err
+}
+
+// EncodeClientRequestW encodes parameters for an XML-RPC client request
+// into the provided io.Writer.
+func EncodeClientRequestW(w io.Writer, method string, args interface{}) error {
+	return rpcRequest2XML(w, method, args)
 }
 
 // DecodeClientResponse decodes the response body of a client request into
 // the interface reply.
 func DecodeClientResponse(r io.Reader, reply interface{}) error {
-	rawxml, err := ioutil.ReadAll(r)
-	if err != nil {
-		return FaultSystemError
-	}
-	return xml2RPC(string(rawxml), reply)
+	return xml2RPC(r, reply)
 }

--- a/xml/fault.go
+++ b/xml/fault.go
@@ -6,6 +6,7 @@ package xml
 
 import (
 	"fmt"
+	"io"
 )
 
 // Default Faults
@@ -33,11 +34,12 @@ func (f Fault) Error() string {
 
 // Fault2XML is a quick 'marshalling' replacemnt for the Fault case.
 func fault2XML(fault Fault) string {
-	buffer := "<methodResponse><fault>"
-	xml, _ := rpc2XML(fault)
-	buffer += xml
-	buffer += "</fault></methodResponse>"
-	return buffer
+	buf := bufPool.Get()
+	defer bufPool.Put(buf)
+	io.WriteString(buf, "<methodResponse><fault>")
+	_ = rpc2XML(buf, fault)
+	io.WriteString(buf, "</fault></methodResponse>")
+	return buf.String()
 }
 
 type faultValue struct {

--- a/xml/pool.go
+++ b/xml/pool.go
@@ -1,0 +1,26 @@
+// Copyright 2015 Tamás Gulácsi
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xml
+
+import (
+	"bytes"
+	"sync"
+)
+
+var bufPool = &bufferPool{
+	Pool: sync.Pool{New: func() interface{} { return bytes.NewBuffer(make([]byte, 0, 1024)) }},
+}
+
+type bufferPool struct {
+	sync.Pool
+}
+
+func (p *bufferPool) Get() *bytes.Buffer {
+	return p.Pool.Get().(*bytes.Buffer)
+}
+func (p *bufferPool) Put(b *bytes.Buffer) {
+	b.Reset()
+	p.Pool.Put(b)
+}

--- a/xml/rpc2xml_test.go
+++ b/xml/rpc2xml_test.go
@@ -27,15 +27,15 @@ type StructRpc2Xml struct {
 
 func TestRPC2XML(t *testing.T) {
 	req := &StructRpc2Xml{123, 3.145926, "Hello, World!", false, SubStructRpc2Xml{42, "I'm Bar", []int{1, 2, 3}}, time.Date(2012, time.July, 17, 14, 8, 55, 0, time.Local), []byte("you can't read this!")}
-	xml, err := rpcRequest2XML("Some.Method", req)
+	buf := bufPool.Get()
+	defer bufPool.Put(buf)
+	err := rpcRequest2XML(buf, "Some.Method", req)
 	if err != nil {
 		t.Error("RPC2XML conversion failed", err)
 	}
 	expected := "<methodCall><methodName>Some.Method</methodName><params><param><value><int>123</int></value></param><param><value><double>3.145926</double></value></param><param><value><string>Hello, World!</string></value></param><param><value><boolean>0</boolean></value></param><param><value><struct><member><name>Foo</name><value><int>42</int></value></member><member><name>Bar</name><value><string>I'm Bar</string></value></member><member><name>Data</name><value><array><data><value><int>1</int></value><value><int>2</int></value><value><int>3</int></value></data></array></value></member></struct></value></param><param><value><dateTime.iso8601>20120717T14:08:55</dateTime.iso8601></value></param><param><value><base64>eW91IGNhbid0IHJlYWQgdGhpcyE=</base64></value></param></params></methodCall>"
-	if xml != expected {
-		t.Error("RPC2XML conversion failed")
-		t.Error("Expected", expected)
-		t.Error("Got", xml)
+	if xml := buf.String(); xml != expected {
+		t.Errorf("RPC2XML conversion failed:\n\tExpected\n%s\n\tgot\n%s", expected, xml)
 	}
 }
 
@@ -45,12 +45,14 @@ type StructSpecialCharsRpc2Xml struct {
 
 func TestRPC2XMLSpecialChars(t *testing.T) {
 	req := &StructSpecialCharsRpc2Xml{" & \" < > "}
-	xml, err := rpcResponse2XML(req)
+	buf := bufPool.Get()
+	defer bufPool.Put(buf)
+	err := rpcResponse2XML(buf, req)
 	if err != nil {
 		t.Error("RPC2XML conversion failed", err)
 	}
 	expected := "<methodResponse><params><param><value><string> &amp; &quot; &lt; &gt; </string></value></param></params></methodResponse>"
-	if xml != expected {
+	if xml := buf.String(); xml != expected {
 		t.Error("RPC2XML Special chars conversion failed")
 		t.Error("Expected", expected)
 		t.Error("Got", xml)
@@ -63,12 +65,14 @@ type StructNilRpc2Xml struct {
 
 func TestRpc2XmlNil(t *testing.T) {
 	req := &StructNilRpc2Xml{nil}
-	xml, err := rpcResponse2XML(req)
+	buf := bufPool.Get()
+	defer bufPool.Put(buf)
+	err := rpcResponse2XML(buf, req)
 	if err != nil {
 		t.Error("RPC2XML conversion failed", err)
 	}
 	expected := "<methodResponse><params><param><value><nil/></value></param></params></methodResponse>"
-	if xml != expected {
+	if xml := buf.String(); xml != expected {
 		t.Error("RPC2XML Special chars conversion failed")
 		t.Error("Expected", expected)
 		t.Error("Got", xml)

--- a/xml/xml2rpc_test.go
+++ b/xml/xml2rpc_test.go
@@ -6,6 +6,7 @@ package xml
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -28,7 +29,7 @@ type StructXml2Rpc struct {
 
 func TestXML2RPC(t *testing.T) {
 	req := new(StructXml2Rpc)
-	err := xml2RPC("<methodCall><methodName>Some.Method</methodName><params><param><value><i4>123</i4></value></param><param><value><double>3.145926</double></value></param><param><value><string>Hello, World!</string></value></param><param><value><boolean>0</boolean></value></param><param><value><struct><member><name>Foo</name><value><int>42</int></value></member><member><name>Bar</name><value><string>I'm Bar</string></value></member><member><name>Data</name><value><array><data><value><int>1</int></value><value><int>2</int></value><value><int>3</int></value></data></array></value></member></struct></value></param><param><value><dateTime.iso8601>20120717T14:08:55</dateTime.iso8601></value></param><param><value><base64>eW91IGNhbid0IHJlYWQgdGhpcyE=</base64></value></param></params></methodCall>", req)
+	err := xml2RPC(strings.NewReader("<methodCall><methodName>Some.Method</methodName><params><param><value><i4>123</i4></value></param><param><value><double>3.145926</double></value></param><param><value><string>Hello, World!</string></value></param><param><value><boolean>0</boolean></value></param><param><value><struct><member><name>Foo</name><value><int>42</int></value></member><member><name>Bar</name><value><string>I'm Bar</string></value></member><member><name>Data</name><value><array><data><value><int>1</int></value><value><int>2</int></value><value><int>3</int></value></data></array></value></member></struct></value></param><param><value><dateTime.iso8601>20120717T14:08:55</dateTime.iso8601></value></param><param><value><base64>eW91IGNhbid0IHJlYWQgdGhpcyE=</base64></value></param></params></methodCall>"), req)
 	if err != nil {
 		t.Error("XML2RPC conversion failed", err)
 	}
@@ -46,7 +47,7 @@ type StructSpecialCharsXml2Rpc struct {
 
 func TestXML2RPCSpecialChars(t *testing.T) {
 	req := new(StructSpecialCharsXml2Rpc)
-	err := xml2RPC("<methodResponse><params><param><value><string> &amp; &quot; &lt; &gt; </string></value></param></params></methodResponse>", req)
+	err := xml2RPC(strings.NewReader("<methodResponse><params><param><value><string> &amp; &quot; &lt; &gt; </string></value></param></params></methodResponse>"), req)
 	if err != nil {
 		t.Error("XML2RPC conversion failed", err)
 	}
@@ -64,7 +65,7 @@ type StructNilXml2Rpc struct {
 
 func TestXML2RPCNil(t *testing.T) {
 	req := new(StructNilXml2Rpc)
-	err := xml2RPC("<methodResponse><params><param><value><nil/></value></param></params></methodResponse>", req)
+	err := xml2RPC(strings.NewReader("<methodResponse><params><param><value><nil/></value></param></params></methodResponse>"), req)
 	if err != nil {
 		t.Error("XML2RPC conversion failed", err)
 	}
@@ -88,7 +89,7 @@ type StructXml2RpcHelloArgs struct {
 
 func TestXML2RPCLowercasedMethods(t *testing.T) {
 	req := new(StructXml2RpcHelloArgs)
-	err := xml2RPC("<methodCall><params><param><value><struct><member><name>string1</name><value><string>I'm a first string</string></value></member><member><name>string2</name><value><string>I'm a second string</string></value></member><member><name>id</name><value><int>1</int></value></member></struct></value></param></params></methodCall>", req)
+	err := xml2RPC(strings.NewReader("<methodCall><params><param><value><struct><member><name>string1</name><value><string>I'm a first string</string></value></member><member><name>string2</name><value><string>I'm a second string</string></value></member><member><name>id</name><value><int>1</int></value></member></struct></value></param></params></methodCall>"), req)
 	if err != nil {
 		t.Error("XML2RPC conversion failed", err)
 	}
@@ -113,7 +114,7 @@ Requiredattribute'user'notfound:
 [{'User',"gggg"},{'Host',"sss.com"},{'Password',"ssddfsdf"}]
 `
 
-	err := xml2RPC(data, req)
+	err := xml2RPC(strings.NewReader(data), req)
 
 	fault, ok := err.(Fault)
 	if !ok {
@@ -140,7 +141,7 @@ Requiredattribute'user'notfound:
 [{'User',"Öñä"},{'Host',"sss.com"},{'Password',"ssddfsdf"}]
 `
 
-	err := xml2RPC(data, req)
+	err := xml2RPC(strings.NewReader(data), req)
 
 	fault, ok := err.(Fault)
 	if !ok {

--- a/xml/xml_test.go
+++ b/xml/xml_test.go
@@ -116,9 +116,8 @@ func execute(t *testing.T, s *rpc.Server, method string, req, res interface{}) e
 		t.Fatal("Expected to be registered:", method)
 	}
 
-	buf, _ := EncodeClientRequest(method, req)
-	body := bytes.NewBuffer(buf)
-	r, _ := http.NewRequest("POST", "http://localhost:8080/", body)
+	b, _ := EncodeClientRequest(method, req)
+	r, _ := http.NewRequest("POST", "http://localhost:8080/", bytes.NewReader(b))
 	r.Header.Set("Content-Type", "text/xml")
 
 	w := httptest.NewRecorder()
@@ -129,26 +128,29 @@ func execute(t *testing.T, s *rpc.Server, method string, req, res interface{}) e
 
 func TestRPC2XMLConverter(t *testing.T) {
 	req := &Service1Request{4, 2}
-	xml, err := rpcRequest2XML("Some.Method", req)
+	buf := bufPool.Get()
+	defer bufPool.Put(buf)
+	err := rpcRequest2XML(buf, "Some.Method", req)
 	if err != nil {
 		t.Error("RPC2XML conversion failed", err)
 	}
 
 	expected := "<methodCall><methodName>Some.Method</methodName><params><param><value><int>4</int></value></param><param><value><int>2</int></value></param></params></methodCall>"
-	if xml != expected {
+	if xml := buf.String(); xml != expected {
 		t.Error("RPC2XML conversion failed")
 		t.Error("Expected", expected)
 		t.Error("Got", xml)
 	}
 
 	req2 := &Service2Request{"Johnny", 33, true}
-	xml, err = rpcRequest2XML("Some.Method", req2)
+	buf.Reset()
+	err = rpcRequest2XML(buf, "Some.Method", req2)
 	if err != nil {
 		t.Error("RPC2XML conversion failed", err)
 	}
 
 	expected = "<methodCall><methodName>Some.Method</methodName><params><param><value><string>Johnny</string></value></param><param><value><int>33</int></value></param><param><value><boolean>1</boolean></value></param></params></methodCall>"
-	if xml != expected {
+	if xml := buf.String(); xml != expected {
 		t.Error("RPC2XML conversion failed")
 		t.Error("Expected", expected)
 		t.Error("Got", xml)
@@ -157,26 +159,28 @@ func TestRPC2XMLConverter(t *testing.T) {
 	address := Address{221, "Baker str.", "London"}
 	person := Person{"Johnny", "Doe", 33, address}
 	req3 := &Service3Request{person}
-	xml, err = rpcRequest2XML("Some.Method", req3)
+	buf.Reset()
+	err = rpcRequest2XML(buf, "Some.Method", req3)
 	if err != nil {
 		t.Error("RPC2XML conversion failed", err)
 	}
 
 	expected = "<methodCall><methodName>Some.Method</methodName><params><param><value><struct><member><name>Name</name><value><string>Johnny</string></value></member><member><name>Surname</name><value><string>Doe</string></value></member><member><name>Age</name><value><int>33</int></value></member><member><name>Address</name><value><struct><member><name>Number</name><value><int>221</int></value></member><member><name>Street</name><value><string>Baker str.</string></value></member><member><name>Country</name><value><string>London</string></value></member></struct></value></member></struct></value></param></params></methodCall>"
-	if xml != expected {
+	if xml := buf.String(); xml != expected {
 		t.Error("RPC2XML conversion failed")
 		t.Error("Expected", expected)
 		t.Error("Got", xml)
 	}
 
 	res := &Service1Response{42}
-	xml, err = rpcResponse2XML(res)
+	buf.Reset()
+	err = rpcResponse2XML(buf, res)
 	if err != nil {
 		t.Error("RPC2XML conversion failed", err)
 	}
 
 	expected = "<methodResponse><params><param><value><int>42</int></value></param></params></methodResponse>"
-	if xml != expected {
+	if xml := buf.String(); xml != expected {
 		t.Error("RPC2XML conversion failed")
 		t.Error("Expected", expected)
 		t.Error("Got", xml)


### PR DESCRIPTION
Helps with big responses.

For backward compatibility, EncodeClientRequest does not change,
just introduce a new

    EncodeClientRequestW(io.Writer, string, interface{}) error

function.


This is a follow-up of #8, without the maps, and proper error handling in writers.