### PR TITLE
Pass on faults from methods.

### DIFF
--- a/xml/server.go
+++ b/xml/server.go
@@ -104,6 +104,16 @@ func (c *CodecRequest) WriteResponse(w http.ResponseWriter, response interface{}
 			fault.String += fmt.Sprintf(": %v", c.err)
 		}
 		xmlstr = fault2XML(fault)
+	} else if methodErr != nil {
+		var fault Fault
+		switch methodErr.(type) {
+		case Fault:
+			fault = methodErr.(Fault)
+		default:
+			fault = FaultApplicationError
+			fault.String += fmt.Sprintf(": %v", methodErr)
+		}
+		xmlstr = fault2XML(fault)
 	} else {
 		xmlstr, _ = rpcResponse2XML(response)
 	}


### PR DESCRIPTION
This allows services to generate their own faults. eg

```
type HelloService struct{}

func (h *HelloService) Say(r *http.Request, args *struct{Who string}, reply *struct{Message string}) error {
    log.Println("Say", args.Who)
    if args.Who == "poop" {
        return xml.Fault{
            Code: 90,
            String: "I refuse to say rude words!",
        }
    }
    reply.Message = "Hello, " + args.Who + "!"
    return nil
}
```

