### PR TITLE
Support for empty arrays

### DIFF
--- a/xml/xml2rpc.go
+++ b/xml/xml2rpc.go
@@ -151,6 +151,8 @@ func value2Field(value value, field *reflect.Value) error {
 		}
 		f = reflect.AppendSlice(f, slice)
 		val = f.Interface()
+	case len(value.Array) == 0:
+		val = val
 
 	default:
 		// value field is default to string, see http://en.wikipedia.org/wiki/XML-RPC#Data_types


### PR DESCRIPTION
According to [XML-RPC specification](http://xmlrpc.scripting.com/spec.html), empty arrays are allowed:

    "An <array> contains a single <data> element, which can contain any number of <value>s."

But currently, Gorilla XML-RPC returns a string with the XML tags, not an empty array. With this Pull Request, an empty array is returned properly.

The problem can be reproduced with the following XML data:
```
<array>
   <data />
 </array>
```

This fix is from @vhanla on issue 24:
https://github.com/divan/gorilla-xmlrpc/issues/24#issuecomment-364224100

All the credit for this solution goes to him, I'm only doing the PR.
