### PR TITLE
Added support for unknown or mixed arrays

### DIFF
--- a/xml/xml2rpc.go
+++ b/xml/xml2rpc.go
@@ -163,7 +163,7 @@ func value2Field(value value, field *reflect.Value) error {
 	}
 
 	if val != nil {
-		if reflect.TypeOf(val) != reflect.TypeOf(field.Interface()) {
+		if reflect.TypeOf(val) != reflect.TypeOf(field.Interface()) && field.Kind() != reflect.Interface {
 			fault := FaultInvalidParams
 			fault.String += fmt.Sprintf(": fields type mismatch: %s != %s",
 				reflect.TypeOf(val),

--- a/xml/xml2rpc_test.go
+++ b/xml/xml2rpc_test.go
@@ -154,3 +154,29 @@ Requiredattribute'user'notfound:
 		}
 	}
 }
+
+type StructXml2RpcUnknown struct {
+	Foo  interface{}
+	Data []interface{}
+}
+
+func TestXML2RPCUnknownTypes(t *testing.T) {
+	req := new(StructXml2RpcUnknown)
+	err := xml2RPC("<methodCall><methodName>Some.Method</methodName><params><param><value><int>42</int></value></param><param><value><array><data><value><int>100</int></value><value><string>Hello</string></value><value><boolean>1</boolean></value></data></array></value></param></params></methodCall>", req)
+	if err != nil {
+		t.Error("XML2RPC conversion failed", err)
+	}
+
+	expected_req := &StructXml2RpcUnknown{
+		Foo: 42,
+	}
+	expected_req.Data = append(expected_req.Data, 100)
+	expected_req.Data = append(expected_req.Data, "Hello")
+	expected_req.Data = append(expected_req.Data, true)
+
+	if !reflect.DeepEqual(req, expected_req) {
+		t.Error("XML2RPC conversion failed")
+		t.Error("Expected", expected_req)
+		t.Error("Got", req)
+	}
+}


### PR DESCRIPTION
Allow library to parse arrays of mixed types (specified as []interface{}).